### PR TITLE
Intercept XHR response

### DIFF
--- a/packages/hyperion-util/src/onNetworkRequest.ts
+++ b/packages/hyperion-util/src/onNetworkRequest.ts
@@ -3,15 +3,15 @@
  */
 
 import { Hook } from "@hyperion/hook";
-import * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
+// import * as IWindow from "@hyperion/hyperion-dom/src/IWindow";
 import * as IXMLHttpRequest from "@hyperion/hyperion-dom/src/IXMLHttpRequest";
 import * as intercept from "@hyperion/hyperion-core/src/intercept";
 import { assert } from "@hyperion/global";
 
-type NetworkRequest = {
+type NetworkRequestInfo = {
   readonly body?: RequestInit['body'],
   readonly method: string;
-  readonly url: string | URL; // TODO: should we always send on of the types?
+  readonly url: string;
 }
 
 /**
@@ -19,42 +19,64 @@ type NetworkRequest = {
  * Generally, various network api can be intercepted to provide a more unified way
  * of notifying the app about network requests.
  */
-export const onNetworkRequest = new Hook<(request: NetworkRequest) => void>();
+export const onNetworkRequestSend = new Hook<(request: XMLHttpRequest, requestInfo: NetworkRequestInfo) => void>();
 
-IWindow.fetch.onArgsObserverAdd((input, init) => {
-  let request: NetworkRequest;
-  if (typeof input === "string") {
-    request = {
-      body: init?.body,
-      method: init?.method ?? "get",
-      url: input,
-    };
-  } else if (input instanceof Request) {
-    request = {
-      body: input.body,
-      method: input.method,
-      url: input.url,
-    }
-  } else {
-    request = {
-      method: "GET",
-      url: input
-    }
-  }
+/**
+ * This is a generic event to be fired when a network request has completed,
+ * whether successfully or unsuccessfully.
+ */
+export const onNetworkRequestLoad = new Hook<(request: XMLHttpRequest) => void>();
 
-  onNetworkRequest.call(request);
-});
+// IWindow.fetch.onArgsObserverAdd((resource, options) => {
+//   let requestInfo: NetworkRequestInfo;
+//   if (resource instanceof Request) {
+//     requestInfo = {
+//       body: resource.body,
+//       method: resource.method,
+//       url: resource.url,
+//     }
+//   } else {
+//     const url = (typeof resource === "string")
+//       ? resource
+//       : resource.toString();
+//     requestInfo = {
+//       body: options?.body,
+//       method: options?.method ?? "get",
+//       url,
+//     }
+//   }
+
+//   onNetworkRequestSend.call(resource, requestInfo);
+// });
 
 //#region XHR
 const XHR_REQUEST_INFO_PROP = 'requestInfo';
 IXMLHttpRequest.open.onArgsObserverAdd(function (this, method, url) {
-  intercept.setVirtualPropertyValue<NetworkRequest>(this, XHR_REQUEST_INFO_PROP, { method, url });
+  intercept.setVirtualPropertyValue<NetworkRequestInfo>(
+    this,
+    XHR_REQUEST_INFO_PROP,
+    {
+      method,
+      url: url instanceof URL
+        ? url.href
+        : url,
+   });
 });
 
 IXMLHttpRequest.send.onArgsObserverAdd(function (this, body) {
-  const request = intercept.getVirtualPropertyValue<NetworkRequest>(this, XHR_REQUEST_INFO_PROP);
-  assert(request != null, `Unexpected situation! Request info is missing from xhr object`);
-  onNetworkRequest.call((body instanceof Document) ? request : {...request, body}); // assert already ensures request is not undefined
+  this.addEventListener('loadend', (event) => {
+    if (event.target instanceof XMLHttpRequest) {
+      onNetworkRequestLoad.call(event.target);
+    }
+  });
+
+  const requestInfo = intercept.getVirtualPropertyValue<NetworkRequestInfo>(this, XHR_REQUEST_INFO_PROP);
+  // assert ensures requestInfo is not undefined
+  assert(requestInfo != null, `Unexpected situation! Request info is missing from xhr object`);
+  onNetworkRequestSend.call(
+    this,
+    (body instanceof Document) ? requestInfo : {...requestInfo, body},
+  );
 });
 //#endregion
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export { trackElementsWithAttributes } from "@hyperion/hyperion-util/src/trackEl
 export * as SyncMutationObserver from "@hyperion/hyperion-util/src/SyncMutationObserver";
 
 // hyperionOnNetworkRequest
-export { onNetworkRequest } from "@hyperion/hyperion-util/src/onNetworkRequest";
+export { onNetworkRequestLoad, onNetworkRequestSend } from "@hyperion/hyperion-util/src/onNetworkRequest";
 
 // hyperionFlowletCore
 export { Flowlet } from "@hyperion/hyperion-flowlet/src/Flowlet";


### PR DESCRIPTION
Added a new hook for the XHR `loadend` event, also modifying the existing `onNetworkRequest` hook to include the XHR request instance itself in order to enable tracking the same flowlet with the request instance. Requesting feedback on this approach and how to best scale this for `fetch` calls as well.