### PR TITLE
Added TimedTrigger utility

### DIFF
--- a/packages/hyperion-util/src/TimedTrigger.ts
+++ b/packages/hyperion-util/src/TimedTrigger.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+type TimeoutID = number;
+
+/**
+ * This class can be used when we want to run a function once either by calling
+ * it explicitly, or have it run after a certain time automatically.
+ * It also allows cancelling or delaying the function if it has not yet
+ * executed.
+ * The class also exposes the current state of the function.
+ *
+ * Generally, this is useful utility for handling state changes that may
+ * have a time element as well.
+ *
+ * The final callback function will know if it was called directly or by the
+ * timer.
+ */
+export class TimedTrigger {
+  _timeoutID: TimeoutID | null = null;
+  _timerFired: boolean = false;
+  _delay: number;
+  _action: null | ((timerFired: boolean) => void);
+
+  constructor(action: (timerFired: boolean) => void, delay: number) {
+    this._action = action;
+    this._delay = delay;
+    this._setTimer();
+  }
+
+  _clearTimer() {
+    if (this._timeoutID != null) {
+      clearTimeout(this._timeoutID);
+    }
+    this._timeoutID = null;
+  }
+
+  _setTimer() {
+    if (!this.isDone()) {
+      this._clearTimer();
+      this._timeoutID = setTimeout(() => {
+        this._timerFired = true;
+        this.run();
+      }, this._delay);
+    }
+  }
+
+  isDone(): boolean {
+    return this._action === null;
+  }
+
+  isCancelled(): boolean {
+    return this._timeoutID === null && this._action !== null;
+  }
+
+  run() {
+    this._clearTimer();
+    if (this._action != null) {
+      // Copy and change before calling so we know this isDone
+      const action = this._action;
+      this._action = null;
+      action(this._timerFired);
+    }
+  }
+
+  getDelay(): number {
+    return this._delay;
+  }
+
+  delay(delay?: number) {
+    this._delay = delay ?? this._delay;
+    this._setTimer();
+  }
+
+  cancel() {
+    this._clearTimer();
+  }
+}

--- a/packages/hyperion-util/test/TimedTrigger.test.ts
+++ b/packages/hyperion-util/test/TimedTrigger.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved.
+ */
+
+'use strict';
+
+import { TimedTrigger } from '../src/TimedTrigger';
+
+describe("timed trigger", () => {
+  /**
+   * There seems to be change in node v19 that prevents fake timers
+   * to work. I keep the commented code needed for running with fake timers
+   * but for now use async tests to continue having poroper tests.
+   */
+  // jest.useFakeTimers();
+
+  test('call once', () => {
+    let count = 0;
+    const f = new TimedTrigger(() => {
+      count++;
+    }, 100);
+
+    f.run();
+    f.run();
+
+    expect(f.isDone()).toBe(true);
+    expect(count).toBe(1);
+  });
+
+  test('call timeout', (done) => {
+    let count = 0;
+    const f = new TimedTrigger(() => {
+      count++;
+
+    }, 10);
+
+    new TimedTrigger(() => {
+      // by now the other timer must have run
+      expect(f.isDone()).toBe(true);
+      expect(count).toBe(1);
+      done();
+    }, 100);
+
+    // jest.runAllTimers();
+    // expect(f.isDone()).toBe(true);
+    // expect(count).toBe(1);
+  });
+
+  test('cancelling', (done) => {
+    let count = 0;
+    const f = new TimedTrigger(() => {
+      count++;
+    }, 10);
+    f.cancel();
+
+    new TimedTrigger(() => {
+      // by now the other timer must have run
+      expect(f.isDone()).toBe(false);
+      expect(f.isCancelled()).toBe(true);
+      expect(count).toBe(0);
+      done();
+    }, 100);
+
+    // jest.runAllTimers();
+    // expect(f.isDone()).toBe(false);
+    // expect(f.isCancelled()).toBe(true);
+    // expect(count).toBe(0);
+  });
+
+  // jest.useRealTimers();
+});


### PR DESCRIPTION
This utility is needed by many features in the hyperion-autologging.

It provides a convenient mechanism to run a function only once, either based on time passed, or explicitly. it is usually a good way of running a code based on another event, or having a timeout mechanism in it. It also supports cancelling or delaying the execution.

(Note: this used to be called TimedOnceFunc before in the main repo)